### PR TITLE
Added record_type

### DIFF
--- a/rules/network/net_susp_dns_txt_exec_strings.yml
+++ b/rules/network/net_susp_dns_txt_exec_strings.yml
@@ -12,6 +12,7 @@ logsource:
     category: dns
 detection:
     selection:
+        - record_type: 'TXT'
         answer:
             - '*IEX*'
             - '*Invoke-Expression*'


### PR DESCRIPTION
The references indicate that this rule should apply to TXT records, but without specifying that the "record_type" must be "TXT" there's the potential for a lot of false positives.

"record_type" was chosen as that fits with Splunks "Network Resolution (DNS)" datamodel.